### PR TITLE
Use default application credential

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -15,7 +15,7 @@ Getting started
 
 1. [Add Firebase to your Android Project](https://firebase.google.com/docs/android/setup).
 2. Create a service account as described in [Adding Firebase to your Server](https://firebase.google.com/docs/admin/setup) and download the JSON file.
-  - Copy the private key JSON file to this folder and rename it to `service-account.json`.
+  - Set `GOOGLE_APPLICATION_CREDENTIALS` environment variable to path of downloaded credential file.
 3. Change the `PROJECT_ID` variable in `Configure.java` to your project ID.
 
 Run

--- a/config/src/main/java/com/google/firebase/samples/config/Configure.java
+++ b/config/src/main/java/com/google/firebase/samples/config/Configure.java
@@ -37,9 +37,9 @@ public class Configure {
    * Retrieve a valid access token that can be use to authorize requests to the Remote Config REST
    * API.
    *
-   * This method assumes it is either running in a trusted Google environment like GCP or if running
-   * elsewhere the the GOOGLE_APPLICATION_CREDENTIALS environment variable is set to the path of the
-   * service account credentials file.
+   * This method must be called in either a trusted Google environment like GCP or if running
+   * elsewhere the GOOGLE_APPLICATION_CREDENTIALS environment variable must be set to the path
+   * of the service account credentials file.
    *
    * @return Access token.
    * @throws IOException

--- a/config/src/main/java/com/google/firebase/samples/config/Configure.java
+++ b/config/src/main/java/com/google/firebase/samples/config/Configure.java
@@ -35,7 +35,8 @@ public class Configure {
 
   /**
    * Retrieve a valid access token that can be use to authorize requests to the Remote Config REST
-   * API.
+   * API. If there is no existing access token or if the existing one will expire in less than
+   * five minutes a fresh token is fetched.
    *
    * This method must be called in either a trusted Google environment like GCP or if running
    * elsewhere the GOOGLE_APPLICATION_CREDENTIALS environment variable must be set to the path


### PR DESCRIPTION
Update config quickstart to use default application credential which is best practice for server side Firebase authentication.