### PR TITLE
fix: GoogleCredential to GoogleCredentials

### DIFF
--- a/messaging/build.gradle
+++ b/messaging/build.gradle
@@ -22,6 +22,6 @@ run {
 dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.12'
 
-    compile 'com.google.api-client:google-api-client:1.22.0'
-    compile 'com.google.code.gson:gson:2.8.1'
+    compile 'com.google.auth:google-auth-library-oauth2-http:0.26.0'
+    compile 'com.google.code.gson:gson:2.8.7'
 }

--- a/messaging/src/main/java/com/google/firebase/quickstart/Messaging.java
+++ b/messaging/src/main/java/com/google/firebase/quickstart/Messaging.java
@@ -1,6 +1,5 @@
 package com.google.firebase.quickstart;
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;

--- a/messaging/src/main/java/com/google/firebase/quickstart/Messaging.java
+++ b/messaging/src/main/java/com/google/firebase/quickstart/Messaging.java
@@ -1,6 +1,7 @@
 package com.google.firebase.quickstart;
 
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.auth.oauth2.GoogleCredentials;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
@@ -43,11 +44,11 @@ public class Messaging {
    */
   // [START retrieve_access_token]
   private static String getAccessToken() throws IOException {
-    GoogleCredential googleCredential = GoogleCredential
-        .fromStream(new FileInputStream("service-account.json"))
-        .createScoped(Arrays.asList(SCOPES));
-    googleCredential.refreshToken();
-    return googleCredential.getAccessToken();
+    GoogleCredentials googleCredentials = GoogleCredentials
+            .fromStream(new FileInputStream("service-account.json"))
+            .createScoped(Arrays.asList(SCOPES));
+    googleCredentials.refreshAccessToken();
+    return googleCredentials.getAccessToken().getTokenValue();
   }
   // [END retrieve_access_token]
 


### PR DESCRIPTION
GoogleCredential is deprecated it is recommended that we use GoogleCredentials instead.

This PR updates the snippet to use the recommended library.