### PR TITLE
fix: Retrieve fcm access token

### DIFF
--- a/messaging/src/main/java/com/google/firebase/quickstart/Messaging.java
+++ b/messaging/src/main/java/com/google/firebase/quickstart/Messaging.java
@@ -46,8 +46,7 @@ public class Messaging {
     GoogleCredentials googleCredentials = GoogleCredentials
             .fromStream(new FileInputStream("service-account.json"))
             .createScoped(Arrays.asList(SCOPES));
-    googleCredentials.refreshAccessToken();
-    return googleCredentials.getAccessToken().getTokenValue();
+    return googleCredentials.refreshAccessToken().getTokenValue();
   }
   // [END retrieve_access_token]
 


### PR DESCRIPTION
This should be:

```
googleCredentials.refreshAccessToken().getTokenValue();
```

Or

```
googleCredentials.refresh();
googleCredentials.AccessToken().getTokenValue();
```

Refer to: https://googleapis.dev/java/google-auth-library/latest/com/google/auth/oauth2/OAuth2Credentials.html#getAccessToken--